### PR TITLE
Add Traveler's Backpack support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,17 @@ repositories {
         name = "Ladysnake Libs"
         url = 'https://maven.ladysnake.org/releases'
     }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 dependencies {
@@ -42,6 +53,7 @@ dependencies {
     modImplementation "dev.emi:trinkets:3.7.0"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-base:5.2.0"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:5.2.0"
+    modImplementation "maven.modrinth:travelersbackpack:XFdxMe7g"
     }
 
 processResources {

--- a/src/main/java/com/imoonday/soulbound/SoulBoundEnchantment.java
+++ b/src/main/java/com/imoonday/soulbound/SoulBoundEnchantment.java
@@ -1,5 +1,7 @@
 package com.imoonday.soulbound;
 
+import com.tiviacz.travelersbackpack.component.ComponentUtils;
+
 import dev.emi.trinkets.api.TrinketEnums;
 import dev.emi.trinkets.api.event.TrinketDropCallback;
 import me.shedaniel.autoconfig.AutoConfig;
@@ -16,6 +18,7 @@ import net.minecraft.world.GameRules;
 public class SoulBoundEnchantment extends Enchantment {
 
     private static boolean curios = FabricLoader.getInstance().isModLoaded("trinkets");
+    private static boolean travelersBackpack = FabricLoader.getInstance().isModLoaded("travelersbackpack");
 
     public SoulBoundEnchantment() {
         super(Rarity.RARE, EnchantmentTarget.BREAKABLE, EquipmentSlot.values());
@@ -70,6 +73,23 @@ public class SoulBoundEnchantment extends Enchantment {
                         newPlayer.getInventory().setStack(i, oldStack);
                     } else {
                         newPlayer.getInventory().offerOrDrop(oldStack);
+                    }
+                }
+            }
+
+            if (travelersBackpack) {
+                if (ComponentUtils.isWearingBackpack(oldPlayer)) {
+                    ItemStack backpack = ComponentUtils.getWearingBackpack(oldPlayer);
+                    int level = EnchantmentHelper.getLevel(SoulBound.SOUL_BOUND, backpack);
+                    if (level > 0) {
+                        if (ComponentUtils.isWearingBackpack(newPlayer)) {
+                            newPlayer.getInventory().offerOrDrop(backpack);
+                        } else {
+                            ComponentUtils.getComponent(newPlayer).setWearable(backpack);
+                            ComponentUtils.getComponent(newPlayer).setContents(backpack);
+                            ComponentUtils.sync(newPlayer);
+                            ComponentUtils.syncToTracking(newPlayer);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/imoonday/soulbound/mixin/BackpackUtilsMixin.java
+++ b/src/main/java/com/imoonday/soulbound/mixin/BackpackUtilsMixin.java
@@ -1,0 +1,24 @@
+package com.imoonday.soulbound.mixin;
+
+import com.imoonday.soulbound.SoulBound;
+import com.tiviacz.travelersbackpack.util.BackpackUtils;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+@Mixin(BackpackUtils.class)
+public class BackpackUtilsMixin {
+    @Inject(method = "onPlayerDeath", at = @At("HEAD"), cancellable = true)
+    private static void handleOnPlayerDeath(World world, PlayerEntity player, ItemStack stack, CallbackInfo ci) {
+        if (EnchantmentHelper.getLevel(SoulBound.SOUL_BOUND, stack) > 0) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/soulbound.mixins.json
+++ b/src/main/resources/soulbound.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.imoonday.soulbound.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "BackpackUtilsMixin",
     "PlayerInventoryMixin"
   ],
   "injectors": {


### PR DESCRIPTION
# This PR
This PR adds support for soulbound-enchanted backpacks from the Traveler's Backpack mod.

# Testing
* I have tested this in the development environment with the Traveler's Backpack mod.
* I have tested this in the development environment **without** the Traveler's Backpack mod (to make sure it does not crash).
* I have also tested this in a production environment with both the Traveler's Backpack mod and the Universal Graves mod.