### PR TITLE
Fix TravelersBackpack compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     modImplementation "dev.emi:trinkets:3.7.0"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-base:5.2.0"
     modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:5.2.0"
-    modImplementation "maven.modrinth:travelersbackpack:XFdxMe7g"
+    modImplementation "maven.modrinth:travelersbackpack:C78BanYS"
     }
 
 processResources {

--- a/src/main/java/com/imoonday/soulbound/SoulBoundEnchantment.java
+++ b/src/main/java/com/imoonday/soulbound/SoulBoundEnchantment.java
@@ -162,7 +162,6 @@ public class SoulBoundEnchantment extends Enchantment {
                             ComponentUtils.getComponent(newPlayer).setWearable(backpack);
                             ComponentUtils.getComponent(newPlayer).setContents(backpack);
                             ComponentUtils.sync(newPlayer);
-                            ComponentUtils.syncToTracking(newPlayer);
                         }
                     }
                 }


### PR DESCRIPTION
I just noticed that Traveler's Backpack removed their `syncToTracking` method, causing SoulBound to crash when a player died with a soulbound traveler's backpack.